### PR TITLE
Add configurable Playwright-based job application bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# Job Application Automation Bot
+
+This repository provides a configurable automation bot that can fill in and submit job application forms automatically. It is built on top of [Playwright](https://playwright.dev/) and exposes a declarative YAML configuration language so that each job posting can be automated without writing Python code.
+
+> ⚠️ **Important:** Many job boards prohibit automated submissions in their Terms of Service. Use this project responsibly and only against workflows you are allowed to automate.
+
+## Features
+
+- Headless or headed browser automation through Playwright.
+- Declarative steps (`goto`, `fill`, `click`, `upload`, `check`, `select`, `wait`, `assert_text`, `press`, `hover`) that map directly onto browser actions.
+- Jinja2 templating for reusing profile data (name, email, links, etc.) across multiple applications.
+- Dry-run mode to review the actions that would be executed without touching the browser.
+- Structured logging that helps you understand what the bot is doing at each step.
+
+## Quick start
+
+1. **Install dependencies**
+
+   ```bash
+   pip install .
+   playwright install
+   ```
+
+2. **Copy the example configuration**
+
+   ```bash
+   cp examples/sample_config.yaml my_jobs.yaml
+   ```
+
+3. **Update the profile information and job steps** in `my_jobs.yaml` so that they match the forms you want to automate.
+
+4. **Run the bot**
+
+   ```bash
+   job-bot run my_jobs.yaml
+   ```
+
+   You can pass `--headless/--no-headless` to control the browser UI and `--dry-run` to only print the steps without launching a browser.
+
+## Configuration format
+
+The configuration file is composed of three sections:
+
+- `profile`: reusable details about you (name, contact info, links, resumes, etc.).
+- `browser`: global browser settings such as headless mode and base timeout.
+- `jobs`: an array of job-specific automation flows.
+
+Each job contains a `url` and a list of `steps`. Every step has an `action` and optional parameters depending on the action type. String values are rendered with Jinja2 so you can reference `profile` fields like `{{ profile.full_name }}` or `{{ profile.resume }}`.
+
+The template context also exposes a helper `path(<relative_path>)` that resolves files relative to the configuration file. This is useful for pointing to documents such as resumes or cover letters kept alongside the YAML file.
+
+See [`examples/sample_config.yaml`](examples/sample_config.yaml) for a fully annotated example.
+
+## Extending the bot
+
+New actions can be added by extending `job_bot.bot.ACTION_HANDLERS`. Each handler receives the Playwright `page`, the rendered step definition, and the runtime context. You can implement logic for complex multi-page flows, captcha solving integrations, or API-based submissions.
+
+## Disclaimer
+
+Automating job applications may violate site policies and could lead to account suspension. This project is provided for educational purposes only. The maintainers are not responsible for any misuse.

--- a/examples/sample_config.yaml
+++ b/examples/sample_config.yaml
@@ -1,0 +1,57 @@
+# Example configuration for the job application automation bot.
+# Copy this file and adapt it to the forms you want to automate.
+
+profile:
+  full_name: Jane Doe
+  email: jane.doe@example.com
+  phone: "+1 555-0100"
+  linkedin: https://www.linkedin.com/in/janedoe
+  github: https://github.com/janedoe
+  resume: "{{ path('documents/resume.pdf') }}"
+  cover_letter: "{{ path('documents/cover_letter.pdf') }}"
+
+browser:
+  headless: true
+  timeout_ms: 15000
+  slow_mo: 50
+
+jobs:
+  - name: Example Job Board
+    url: https://example.com/careers/12345
+    steps:
+      - action: wait_for_selector
+        selector: "form.application"
+        state: visible
+      - action: fill
+        selector: "input[name='first_name']"
+        value: "{{ profile.full_name.split(' ')[0] }}"
+      - action: fill
+        selector: "input[name='last_name']"
+        value: "{{ profile.full_name.split(' ')[1] }}"
+      - action: fill
+        selector: "input[name='email']"
+        value: "{{ profile.email }}"
+      - action: fill
+        selector: "input[name='phone']"
+        value: "{{ profile.phone }}"
+      - action: fill
+        selector: "input[name='linkedin']"
+        value: "{{ profile.linkedin }}"
+      - action: fill
+        selector: "input[name='github']"
+        value: "{{ profile.github }}"
+      - action: upload
+        selector: "input[type='file'][name='resume']"
+        files: "{{ profile.resume }}"
+      - action: upload
+        selector: "input[type='file'][name='cover_letter']"
+        files: "{{ profile.cover_letter }}"
+      - action: check
+        selector: "input[name='terms']"
+        checked: true
+      - action: click
+        selector: "button[type='submit']"
+      - action: wait
+        duration_ms: 2000
+      - action: assert_text
+        text: "Thank you for applying"

--- a/job_bot/__init__.py
+++ b/job_bot/__init__.py
@@ -1,0 +1,6 @@
+"""Job application automation bot package."""
+
+from .bot import JobApplicationBot
+from .config import AutomationConfig, load_config
+
+__all__ = ["JobApplicationBot", "AutomationConfig", "load_config"]

--- a/job_bot/bot.py
+++ b/job_bot/bot.py
@@ -1,0 +1,304 @@
+"""Core automation engine for the job application bot."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from dataclasses import asdict
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping
+
+from jinja2 import Environment
+from playwright.sync_api import Browser, Page, TimeoutError as PlaywrightTimeoutError, sync_playwright
+
+from .config import AutomationConfig, JobConfig
+
+LOGGER = logging.getLogger("job_bot")
+if not LOGGER.handlers:
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("[%(levelname)s] %(message)s")
+    handler.setFormatter(formatter)
+    LOGGER.addHandler(handler)
+LOGGER.setLevel(logging.INFO)
+
+
+class JobAutomationError(RuntimeError):
+    """Raised when automation fails for a job."""
+
+
+class JobApplicationBot:
+    """Execute job application flows using Playwright."""
+
+    def __init__(
+        self,
+        config: AutomationConfig,
+        *,
+        headless: bool | None = None,
+    ) -> None:
+        self._config = config
+        self._headless_override = headless
+        self._jinja_env = Environment(autoescape=False)
+        self._jinja_env.globals.update(
+            path=self._path_helper,
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def run(self, *, dry_run: bool = False) -> None:
+        """Run every job listed in the configuration."""
+
+        context = self._build_template_context()
+
+        if dry_run:
+            self._dry_run(context)
+            return
+
+        browser_kwargs: Dict[str, Any] = {
+            "headless": self._headless_override
+            if self._headless_override is not None
+            else self._config.browser.headless,
+        }
+        if self._config.browser.slow_mo is not None:
+            browser_kwargs["slow_mo"] = self._config.browser.slow_mo
+
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(**browser_kwargs)
+            try:
+                for job in self._config.jobs:
+                    LOGGER.info("Running job '%s' (%s)", job.name, job.url)
+                    try:
+                        with self._job_context(browser) as page:
+                            self._execute_job(job, page, context)
+                    except JobAutomationError:
+                        raise
+                    except Exception as exc:  # pragma: no cover - defensive
+                        raise JobAutomationError(
+                            f"Job '{job.name}' failed with unexpected error"
+                        ) from exc
+            finally:
+                browser.close()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _build_template_context(self) -> Dict[str, Any]:
+        raw_profile = dict(self._config.profile)
+        preliminary_context = {"profile": raw_profile}
+        rendered_profile = self._render(raw_profile, preliminary_context)
+        return {"profile": rendered_profile}
+
+    def _path_helper(self, relative: str) -> str:
+        path = (self._config.base_dir / relative).expanduser().resolve()
+        return str(path)
+
+    def _render(self, value: Any, context: Mapping[str, Any]) -> Any:
+        if isinstance(value, str):
+            template = self._jinja_env.from_string(value)
+            return template.render(**context)
+        if isinstance(value, Mapping):
+            return {k: self._render(v, context) for k, v in value.items()}
+        if isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray)):
+            return [self._render(item, context) for item in value]
+        return value
+
+    def _dry_run(self, context: Mapping[str, Any]) -> None:
+        for job in self._config.jobs:
+            LOGGER.info("[dry-run] Job '%s' -> %s", job.name, job.url)
+            job_context = {**context, "job": asdict(job)}
+            for index, step in enumerate(job.steps, start=1):
+                rendered = self._render({"action": step.action, **step.options}, job_context)
+                LOGGER.info("  Step %02d: %s", index, rendered)
+
+    @contextmanager
+    def _job_context(self, browser: Browser) -> Iterable[Page]:
+        kwargs = {}
+        if self._config.browser.locale:
+            kwargs["locale"] = self._config.browser.locale
+        context = browser.new_context(**kwargs)
+        try:
+            page = context.new_page()
+            yield page
+        finally:
+            context.close()
+
+    def _execute_job(
+        self,
+        job: JobConfig,
+        page: Page,
+        global_context: Mapping[str, Any],
+    ) -> None:
+        job_context = {**global_context, "job": {"name": job.name, **job.metadata}}
+        timeout_ms = self._config.browser.timeout_ms
+
+        self._goto(page, job.url, timeout_ms)
+
+        for index, step in enumerate(job.steps, start=1):
+            rendered_step = self._render({"action": step.action, **step.options}, job_context)
+            action = rendered_step.pop("action")
+            LOGGER.info("  step %02d -> %s", index, action)
+            handler = ACTION_HANDLERS.get(action)
+            if not handler:
+                raise JobAutomationError(f"Unsupported action '{action}'")
+            try:
+                handler(page, rendered_step, timeout_ms, self)
+            except PlaywrightTimeoutError as exc:
+                raise JobAutomationError(
+                    f"Timed out waiting for selector during step {index} ({action})"
+                ) from exc
+
+    def _goto(self, page: Page, url: str, timeout_ms: int) -> None:
+        LOGGER.info("  navigating to %s", url)
+        page.goto(url, wait_until="load", timeout=timeout_ms)
+
+
+# ----------------------------------------------------------------------
+# Action handlers
+# ----------------------------------------------------------------------
+
+
+def _require_selector(step: MutableMapping[str, Any]) -> str:
+    selector = step.get("selector")
+    if not selector:
+        raise JobAutomationError("Step requires a 'selector'")
+    return str(selector)
+
+
+def _ensure_files(bot: JobApplicationBot, value: Any) -> List[str]:
+    if isinstance(value, (list, tuple)):
+        files = [str(v) for v in value]
+    else:
+        files = [str(value)]
+    return [bot._path_helper(path) for path in files]
+
+
+def handle_fill(page: Page, step: MutableMapping[str, Any], timeout_ms: int, bot: JobApplicationBot) -> None:
+    selector = _require_selector(step)
+    if "value" not in step:
+        raise JobAutomationError("Fill action requires a 'value'")
+    value = step.get("value")
+    page.fill(selector, str(value), timeout=timeout_ms)
+
+
+def handle_type(page: Page, step: MutableMapping[str, Any], timeout_ms: int, bot: JobApplicationBot) -> None:
+    selector = _require_selector(step)
+    value = step.get("value", "")
+    delay = step.get("delay")
+    kwargs = {"timeout": timeout_ms}
+    if delay is not None:
+        kwargs["delay"] = int(delay)
+    page.type(selector, str(value), **kwargs)
+
+
+def handle_click(page: Page, step: MutableMapping[str, Any], timeout_ms: int, bot: JobApplicationBot) -> None:
+    selector = _require_selector(step)
+    kwargs = {"timeout": timeout_ms}
+    if "button" in step:
+        kwargs["button"] = str(step["button"])
+    if "click_count" in step:
+        kwargs["click_count"] = int(step["click_count"])
+    if "delay" in step:
+        kwargs["delay"] = int(step["delay"])
+    page.click(selector, **kwargs)
+
+
+def handle_check(page: Page, step: MutableMapping[str, Any], timeout_ms: int, bot: JobApplicationBot) -> None:
+    selector = _require_selector(step)
+    if step.get("checked", True):
+        page.check(selector, timeout=timeout_ms)
+    else:
+        page.uncheck(selector, timeout=timeout_ms)
+
+
+def handle_select(page: Page, step: MutableMapping[str, Any], timeout_ms: int, bot: JobApplicationBot) -> None:
+    selector = _require_selector(step)
+    value = step.get("value")
+    values = step.get("values")
+    if value is None and values is None:
+        raise JobAutomationError("Select action requires 'value' or 'values'")
+    kwargs: Dict[str, Any] = {"timeout": timeout_ms}
+    if value is not None:
+        kwargs["value"] = str(value)
+    if values is not None:
+        if isinstance(values, Iterable) and not isinstance(values, str):
+            kwargs["values"] = [str(v) for v in values]
+        else:
+            kwargs["values"] = [str(values)]
+    page.select_option(selector, **kwargs)
+
+
+def handle_upload(page: Page, step: MutableMapping[str, Any], timeout_ms: int, bot: JobApplicationBot) -> None:
+    selector = _require_selector(step)
+    if "files" not in step:
+        raise JobAutomationError("Upload action requires 'files'")
+    files = _ensure_files(bot, step.get("files"))
+    page.set_input_files(selector, files, timeout=timeout_ms)
+
+
+def handle_wait(page: Page, step: MutableMapping[str, Any], timeout_ms: int, bot: JobApplicationBot) -> None:
+    duration = int(step.get("duration_ms") or step.get("ms") or 1000)
+    page.wait_for_timeout(duration)
+
+
+def handle_wait_for_selector(page: Page, step: MutableMapping[str, Any], timeout_ms: int, bot: JobApplicationBot) -> None:
+    selector = _require_selector(step)
+    state = step.get("state")
+    kwargs = {"timeout": timeout_ms}
+    if state:
+        kwargs["state"] = str(state)
+    page.wait_for_selector(selector, **kwargs)
+
+
+def handle_assert_text(page: Page, step: MutableMapping[str, Any], timeout_ms: int, bot: JobApplicationBot) -> None:
+    selector = step.get("selector")
+    text = step.get("text")
+    if text is None:
+        raise JobAutomationError("assert_text requires 'text'")
+    if selector:
+        locator = page.locator(str(selector))
+        locator.wait_for(state="visible", timeout=timeout_ms)
+        content = locator.inner_text()
+    else:
+        content = page.content()
+    if str(text) not in content:
+        raise JobAutomationError(
+            f"assert_text failed to find '{text}' in the page content"
+        )
+
+
+def handle_press(page: Page, step: MutableMapping[str, Any], timeout_ms: int, bot: JobApplicationBot) -> None:
+    selector = _require_selector(step)
+    keys = step.get("keys") or step.get("key")
+    if not keys:
+        raise JobAutomationError("press requires 'keys' or 'key'")
+    page.press(selector, str(keys), timeout=timeout_ms)
+
+
+def handle_hover(page: Page, step: MutableMapping[str, Any], timeout_ms: int, bot: JobApplicationBot) -> None:
+    selector = _require_selector(step)
+    page.hover(selector, timeout=timeout_ms)
+
+
+def handle_goto(page: Page, step: MutableMapping[str, Any], timeout_ms: int, bot: JobApplicationBot) -> None:
+    url = step.get("url")
+    if not url:
+        raise JobAutomationError("goto action requires 'url'")
+    wait_until = str(step.get("wait_until", "load"))
+    page.goto(str(url), wait_until=wait_until, timeout=timeout_ms)
+
+
+ACTION_HANDLERS = {
+    "goto": handle_goto,
+    "fill": handle_fill,
+    "type": handle_type,
+    "click": handle_click,
+    "check": handle_check,
+    "select": handle_select,
+    "upload": handle_upload,
+    "wait": handle_wait,
+    "wait_for_selector": handle_wait_for_selector,
+    "assert_text": handle_assert_text,
+    "press": handle_press,
+    "hover": handle_hover,
+}
+
+__all__ = ["JobApplicationBot", "JobAutomationError", "ACTION_HANDLERS"]

--- a/job_bot/cli.py
+++ b/job_bot/cli.py
@@ -1,0 +1,42 @@
+"""Command line interface for the job automation bot."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from .bot import JobApplicationBot, JobAutomationError
+from .config import load_config
+
+app = typer.Typer(add_completion=False, help="Automate job application workflows")
+
+
+@app.command()
+def run(
+    config: Path = typer.Argument(..., exists=True, readable=True, help="Path to the YAML configuration file"),
+    headless: Optional[bool] = typer.Option(
+        None,
+        "--headless/--no-headless",
+        help="Override the headless mode defined in the configuration",
+    ),
+    dry_run: bool = typer.Option(False, help="Print the actions without running the browser"),
+) -> None:
+    """Execute all jobs defined in the configuration file."""
+
+    try:
+        automation_config = load_config(config)
+    except Exception as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+    bot = JobApplicationBot(automation_config, headless=headless)
+    try:
+        bot.run(dry_run=dry_run)
+    except JobAutomationError as exc:
+        typer.secho(str(exc), fg=typer.colors.RED)
+        raise typer.Exit(code=1) from exc
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/job_bot/config.py
+++ b/job_bot/config.py
@@ -1,0 +1,131 @@
+"""Configuration loader for the job automation bot."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+import yaml
+
+
+@dataclass(slots=True)
+class BrowserConfig:
+    """Settings that control how Playwright launches the browser."""
+
+    headless: bool = True
+    slow_mo: Optional[int] = None
+    timeout_ms: int = 10_000
+    locale: Optional[str] = None
+
+
+@dataclass(slots=True)
+class StepConfig:
+    """A single automation instruction inside a job flow."""
+
+    action: str
+    options: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "StepConfig":
+        if "action" not in data:
+            raise ValueError("Every step must define an 'action' field")
+        action = str(data["action"])
+        options = {k: v for k, v in data.items() if k != "action"}
+        return cls(action=action, options=options)
+
+
+@dataclass(slots=True)
+class JobConfig:
+    """Configuration for a single job posting automation run."""
+
+    name: str
+    url: str
+    steps: List[StepConfig]
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "JobConfig":
+        if "url" not in data:
+            raise ValueError("Each job requires a 'url'")
+        name = str(data.get("name") or data["url"])
+        url = str(data["url"])
+        raw_steps = data.get("steps") or []
+        if not isinstance(raw_steps, Iterable):
+            raise ValueError("Job 'steps' must be an iterable of step definitions")
+        steps = [StepConfig.from_mapping(step) for step in raw_steps]
+        metadata = {
+            k: v
+            for k, v in data.items()
+            if k not in {"name", "url", "steps"}
+        }
+        return cls(name=name, url=url, steps=steps, metadata=metadata)
+
+
+@dataclass(slots=True)
+class AutomationConfig:
+    """Top-level configuration file representation."""
+
+    source_path: Path
+    profile: Dict[str, Any]
+    browser: BrowserConfig
+    jobs: List[JobConfig]
+
+    @property
+    def base_dir(self) -> Path:
+        return self.source_path.parent
+
+
+def _load_yaml(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+        if not isinstance(data, Mapping):
+            raise ValueError("Configuration root must be a mapping")
+        return dict(data)
+
+
+def _parse_browser_config(data: Mapping[str, Any]) -> BrowserConfig:
+    return BrowserConfig(
+        headless=bool(data.get("headless", True)),
+        slow_mo=data.get("slow_mo"),
+        timeout_ms=int(data.get("timeout_ms", 10_000)),
+        locale=data.get("locale"),
+    )
+
+
+def load_config(path: Path | str) -> AutomationConfig:
+    """Load the YAML configuration into dataclasses."""
+
+    cfg_path = Path(path).expanduser().resolve()
+    raw = _load_yaml(cfg_path)
+
+    profile = raw.get("profile") or {}
+    if not isinstance(profile, Mapping):
+        raise ValueError("'profile' must be a mapping of reusable data")
+    profile = dict(profile)
+
+    browser = _parse_browser_config(raw.get("browser") or {})
+
+    raw_jobs = raw.get("jobs") or []
+    if not isinstance(raw_jobs, Iterable):
+        raise ValueError("'jobs' must be a list of job definitions")
+    jobs = [JobConfig.from_mapping(job) for job in raw_jobs]
+
+    if not jobs:
+        raise ValueError("No jobs defined in configuration")
+
+    return AutomationConfig(
+        source_path=cfg_path,
+        profile=profile,
+        browser=browser,
+        jobs=jobs,
+    )
+
+
+__all__ = [
+    "AutomationConfig",
+    "BrowserConfig",
+    "JobConfig",
+    "StepConfig",
+    "load_config",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "job-bot"
+version = "0.1.0"
+description = "Configurable automation bot that applies to jobs by filling online forms"
+authors = [
+  {name = "Automation Bot", email = "example@example.com"}
+]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "PyYAML>=6.0",
+  "playwright>=1.40.0",
+  "typer[all]>=0.9.0",
+  "jinja2>=3.1.0"
+]
+
+[project.scripts]
+job-bot = "job_bot.cli:app"


### PR DESCRIPTION
## Summary
- add a Playwright-powered automation engine that reads YAML job workflows and executes configurable steps
- expose a Typer-based CLI entrypoint and package metadata for distribution
- document configuration details and provide an example YAML template for automating job submissions

## Testing
- python -m compileall job_bot

------
https://chatgpt.com/codex/tasks/task_e_68e1a9f74150832d82584eafd151d55c